### PR TITLE
Minor change to routineComponent definition

### DIFF
--- a/media-pipe/routines/workout_config.py
+++ b/media-pipe/routines/workout_config.py
@@ -54,9 +54,10 @@ class RoutineConfig:
         self, 
         name: str,
         exercise_detail: ExerciseDetail, 
-        reps: Optional[float] = None, 
+        reps: Optional[float] = 0, 
+        custom_tracking_details: List[TrackingDetail] = []        
     ):
-        self.exercises.append(RoutineComponent(name, exercise_detail, reps))
+        self.exercises.append(RoutineComponent(exercise_detail, reps))
     
     def get_workout(self, exercise_name: str) -> Optional[RoutineComponent]:
         for component in self.exercises:

--- a/media-pipe/routines/workout_config.py
+++ b/media-pipe/routines/workout_config.py
@@ -29,13 +29,13 @@ class ExerciseDetail:
 class RoutineComponent:
     def __init__(
         self,
-        name: str,
         exercise: ExerciseDetail,
-        reps: float,        
+        reps: float,
+        custom_tracking_details: List[TrackingDetail] = []        
     ):
-        self.name = name
         self.exercise = exercise
         self.reps = reps
+        self.custom_tracking_details = custom_tracking_details
         
 
         


### PR DESCRIPTION
From what I remember, routine component shouldn't have a name field, but should have custom tracking details (optional List<TrackingDetail>) as of the most recent plan.  This would be what the planned model should look like, and a "name"-like identifier would come from the exercise detail's display_name.  

(I remember that we're still unsure if this was the best way to handle customizable tracking, so if this is intentionally omitted, then lmk🥇 )  Maybe the name field could be useful for a heavily customized exercise routine with many custom tracking details?